### PR TITLE
Backgrounding behaviour

### DIFF
--- a/PerchRTC/PHConnectionBroker.m
+++ b/PerchRTC/PHConnectionBroker.m
@@ -205,16 +205,20 @@ static BOOL kPHConnectionManagerUseCaptureKit = YES;
 
     XSObjectCompletion socketTokenHandler = ^(id object, NSError *error) {
         dispatch_async(dispatch_get_main_queue(), ^{
+            self.socketTokenTask = nil;
+
             if (!error) {
                 NSString *token = [self parseSocketCredentials:object];
                 [self.room authorizeWithToken:token];
                 [self.peerClient connect];
             }
-            else {
+            else if (error.code != NSURLErrorCancelled) {
                 [self.delegate connectionBroker:self didFailWithError:error];
+                [self checkAuthorizationStatus];
             }
-
-            self.socketTokenTask = nil;
+            else {
+                DDLogVerbose(@"Cancelled peer client authorization.");
+            }
         });
     };
 

--- a/PerchRTC/PerchRTC-Info.plist
+++ b/PerchRTC/PerchRTC-Info.plist
@@ -24,6 +24,11 @@
 	<string>5</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+		<string>voip</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>Launch Screen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/PerchRTC/Renderers/PHSampleBufferRenderer.m
+++ b/PerchRTC/Renderers/PHSampleBufferRenderer.m
@@ -134,7 +134,7 @@ static NSUInteger PHSampleBufferAdaptorDropThreshold = 2;
 - (void)restoreFailedSampleView
 {
     UIView *lastSuperview = self.sampleView.superview;
-    NSUInteger lastIndex = [lastSuperview.subviews indexOfObject:lastSuperview];
+    NSUInteger lastIndex = [lastSuperview.subviews indexOfObject:self.sampleView];
     CGRect lastFrame = self.sampleView.frame;
     CGAffineTransform lastTransform = self.sampleView.transform;
 

--- a/PerchRTC/Renderers/PHSampleBufferRenderer.m
+++ b/PerchRTC/Renderers/PHSampleBufferRenderer.m
@@ -134,6 +134,8 @@ static NSUInteger PHSampleBufferAdaptorDropThreshold = 2;
 - (void)restoreFailedSampleView
 {
     UIView *lastSuperview = self.sampleView.superview;
+    NSArray *lastSubviews = self.sampleView.subviews;
+    NSArray *lastGestureRecognizers = self.sampleView.gestureRecognizers;
     NSUInteger lastIndex = [lastSuperview.subviews indexOfObject:self.sampleView];
     CGRect lastFrame = self.sampleView.frame;
     CGAffineTransform lastTransform = self.sampleView.transform;
@@ -147,6 +149,14 @@ static NSUInteger PHSampleBufferAdaptorDropThreshold = 2;
     [self.sampleView addObserver:self forKeyPath:@"layer.status" options:NSKeyValueObservingOptionNew context:NULL];
 
     [lastSuperview insertSubview:self.sampleView atIndex:lastIndex];
+
+    [lastSubviews enumerateObjectsUsingBlock:^(UIView *subview, NSUInteger idx, BOOL *stop) {
+        [self.sampleView addSubview:subview];
+    }];
+
+    [lastGestureRecognizers enumerateObjectsUsingBlock:^(UIGestureRecognizer *recognizer, NSUInteger idx, BOOL *stop) {
+        [self.sampleView addGestureRecognizer:recognizer];
+    }];
 }
 
 - (void)destroyConverters


### PR DESCRIPTION
Adds a couple of improvements related to backgrounding and the app lifecycle.

Restore sample buffer renderer (#1) 
- Restore the view to the correct index, including subviews and gesture recognizers
- Though this was pretty hacky in the first place, it should at least work properly

Signaling reconnection (#3)
- Keep track of the number of retry attempts
- Retry while reachable up to the attempt limit
- Nothing too fancy here, didn't add any retry delays

Add VOIP, and Audio background modes
- Audio continues to play & record in the background
- Unsure if VOIP mode is needed, or if it really does us any good (since we handle SRWebSocket callbacks on the main queue)
