### PR TITLE
Upgrade SocketRocket

### DIFF
--- a/PerchRTC/XirSys/XSPeerClient.m
+++ b/PerchRTC/XirSys/XSPeerClient.m
@@ -193,15 +193,7 @@ static NSTimeInterval kXSPeerClientKeepaliveInterval = 5.0;
 
 - (void)sendPing
 {
-    NSDictionary *messageDictionary = @{};
-    NSError *jsonError = nil;
-    NSData *data = [NSJSONSerialization dataWithJSONObject:messageDictionary
-                                                   options:0
-                                                     error:&jsonError];
-
-    if (!jsonError) {
-        [self.negotiationSocket send:data];
-    }
+    [self.negotiationSocket sendPing:nil];
 }
 
 - (void)applicationWillEnterForeground

--- a/PerchRTC/XirSys/XSPeerClient.m
+++ b/PerchRTC/XirSys/XSPeerClient.m
@@ -19,7 +19,7 @@ static NSString *kPHConnectionManagerXSWebSocketAddress = @"wss://api.xirsys.com
 /**
  *  XirSys requires a keepalive for presence. The timing constant is taken from their Rails Demo.
  */
-static NSTimeInterval kXSPeerClientKeepaliveInterval = 5.0;
+static NSTimeInterval kXSPeerClientKeepaliveInterval = 20.0;
 
 @interface XSPeerClient() <SRWebSocketDelegate>
 

--- a/Podfile
+++ b/Podfile
@@ -6,7 +6,7 @@ platform :ios, '7.0'
 pod 'CocoaLumberjack'
 pod 'nighthawk-webrtc', :podspec => './nighthawk-webrtc-8444.podspec'
 pod 'XirSys', :git => 'https://github.com/samsymons/XirSys.git'
-pod 'SocketRocket', '= 0.3.1-beta2'
+pod 'SocketRocket', :git => 'https://github.com/square/SocketRocket.git'
 pod 'AFNetworking/Reachability'
 
 link_with 'PerchRTC', 'PerchRTCTests'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -13,16 +13,21 @@ DEPENDENCIES:
   - AFNetworking/Reachability
   - CocoaLumberjack
   - nighthawk-webrtc (from `./nighthawk-webrtc-8444.podspec`)
-  - SocketRocket (= 0.3.1-beta2)
+  - SocketRocket (from `https://github.com/square/SocketRocket.git`)
   - XirSys (from `https://github.com/samsymons/XirSys.git`)
 
 EXTERNAL SOURCES:
   nighthawk-webrtc:
     :podspec: "./nighthawk-webrtc-8444.podspec"
+  SocketRocket:
+    :git: https://github.com/square/SocketRocket.git
   XirSys:
     :git: https://github.com/samsymons/XirSys.git
 
 CHECKOUT OPTIONS:
+  SocketRocket:
+    :commit: d1e796c05a8b6dfa662a7cf3cfdce17d0d88c618
+    :git: https://github.com/square/SocketRocket.git
   XirSys:
     :commit: 53f661de87c3d81e296a360c98a292c9c18f05f1
     :git: https://github.com/samsymons/XirSys.git
@@ -31,7 +36,7 @@ SPEC CHECKSUMS:
   AFNetworking: 96ac9bf3eda33582701cb1fcc5b896aa1e20311e
   CocoaLumberjack: e9b828e64142be63c1c130517b33aa5e235d2413
   nighthawk-webrtc: 7285cac5002b28c2cbdc82a0d896e06391269965
-  SocketRocket: 7284ab9370a06c99aba92b2fe3a32aedd0f9a6fa
+  SocketRocket: 70df1983148525857ced17c57207bfb939bc6b8e
   XirSys: b6184f2667e4b12fa92348f7a1987757087e5cfe
 
 COCOAPODS: 0.37.1


### PR DESCRIPTION
Upgrades SocketRocket to the latest revision on master.
- Use new ping API.
- Reduce ping size, stripping empty dictionary.
- Increase timeout to 20s to match XirSys JS sample.
