### PR TITLE
PHVideoCaptureBridge: Submit frames on WebRTC thread

### DIFF
--- a/PerchRTC/CaptureKit/PHVideoCaptureBridge.h
+++ b/PerchRTC/CaptureKit/PHVideoCaptureBridge.h
@@ -38,6 +38,7 @@ namespace perch {
 
         void CopyCapturedFrame(CMSampleBufferRef incomingFrame);
         void HandleDroppedFrame(CMSampleBufferRef droppedFrame);
+        void SignalFrameCapturedOnStartThread(const cricket::CapturedFrame* frame);
 
         // cricket::VideoCapturer implementation.
 
@@ -50,6 +51,7 @@ namespace perch {
         bool IsScreencast() const override;
         
     private:
+        rtc::Thread* _startThread;  // Set in Start(), unset in Stop().
         id<PHVideoCapture> _captureHandler;
         PHVideoCaptureKit *_owner;
         int64 _initialTimestamp;


### PR DESCRIPTION
Thread affinity checks were introduced in:
https://chromium.googlesource.com/external/webrtc/+/e07710cc91b3dccd7fea7df3d99c304f419babda
so we can no longer submit frames from the AVFoundation thread.

In debug builds, it will result in an assertion. It’s a shame we have to fling things between threads, since AVFoundation already does all the queueing for us, but such is life.

This fix was essentially lifted from:
talk/app/webrtc/objc/avfoundationvideocapturer.mm
